### PR TITLE
Updates weewxcron to only update from api when files are out of date

### DIFF
--- a/updater.php
+++ b/updater.php
@@ -10,7 +10,7 @@ date_default_timezone_set($TZ);
   var refreshId;$(document).ready(function(){stationcron()});function stationcron(){$.ajax({cache:false,
   success:function(a){$("#blank")
   .html(a);<?php if ($wuupdate >0) {
-  echo 'setTimeout(stationcron,' . 221000*$wuupdate.')';}?>},
+  echo 'setTimeout(stationcron,' . 1000*$wuupdate.')';}?>},
   contentType: "application/x-www-form-urlencoded;charset=ISO-8859-15",
   type:"GET",url:"weewxcron.php"})}; 
 

--- a/weewxcron.php
+++ b/weewxcron.php
@@ -1,98 +1,98 @@
 <?php
 include('settings.php');
-include('settings1.php');
-include('meteoalarmsettings.php');
+include('common.php');
 date_default_timezone_set($TZ);
 error_reporting(0);
+$force_stale=(array_key_exists('force', $_GET) && $_GET['force'] == $password);
+# overwrites password...
+include('meteoalarmsettings.php');
+function file_stale($filename, $max_age=0) {
+  global $force_stale; if($force_stale)return true;
+  global $wuupdate; if($max_age==0)$max_age=$wuupdate*0.8;
+  return !(file_exists($filename)&&(time()-filemtime($filename))<$max_age);
+}
+function update_file($ch, $filename) {
+  global $lang;
+  $fp = fopen($filename, 'wb');
+  if(!$fp){curl_close($ch); return;}
+  curl_setopt($ch, CURLOPT_FILE, $fp);
+  curl_setopt($ch, CURLOPT_HEADER, 0);
+  if(curl_exec($ch))
+    echo $filename.' '.$lang['Updated']."<br>";
+  else
+    echo $filename.' - ERR: '.curl_error($ch)."\n";
+  curl_close($ch);
+  fclose($fp);
+}
 ?>
 <?php
-$w34header= array(
-            "X-API-KEY:".$metarapikey."",);
-$ch = curl_init();
+$metarapikey=trim($metarapikey);
+$icao1=trim($icao1);
 $filename2 = 'jsondata/metar34.txt';
+if($metarapikey && $icao1 && file_stale($filename2)) {
+$w34header= array("X-API-KEY:".$metarapikey."",);
 $complete_save_loc2 = $filename2;
-$fp2 = fopen($complete_save_loc2, 'wb');
-curl_setopt($ch, CURLOPT_URL,"https://api.checkwx.com/metar/".$icao1."/decoded");
-curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-curl_setopt($ch, CURLOPT_HTTPHEADER,$w34header);
-curl_setopt($ch, CURLOPT_FILE, $fp2);
-$result = curl_exec ($ch);
-curl_close ($ch);
+$ch = curl_init("https://api.checkwx.com/metar/".$icao1."/decoded");
+curl_setopt($ch, CURLOPT_HTTPHEADER, $w34header);
+update_file($ch, $complete_save_loc2);
+}
 ?>
-
 <?php
 if ($position6=="forecast3ds.php" || $position6=='forecast3wu.php' || $position6=='forecast3wularge.php' || $position4 == "advisory.php"){
 // weather34 darksky  curl based
+$apikey=trim($apikey);
+$filename4a = 'jsondata/darksky.txt';
+if($apikey && file_stale($filename4a, 3600*0.8)){
 $url4a = 'https://api.forecast.io/forecast/'.$apikey.'/'.$lat.','.$lon.'?lang='.$language.'&units='.$darkskyunit ;
 $ch4a = curl_init($url4a);
-$filename4a = 'jsondata/darksky.txt';
 $complete_save_loc4a = $filename4a;
-$fp4a = fopen($complete_save_loc4a, 'wb');
-curl_setopt($ch4a, CURLOPT_FILE, $fp4a);
-curl_setopt($ch4a, CURLOPT_HEADER, 0);
-curl_exec($ch4a);
-curl_close($ch4a);
-fclose($fp4a);}?>
-
-
-
+update_file($ch4a, $complete_save_loc4a);
+}}?>
 <?php
 if ($position6=="forecast3wu.php" || $position6=="forecast3wularge.php"){
 // weather34 weather underground  curl based
+$wuapikey=trim($wuapikey);
+$filename4c = 'jsondata/wuforecast.txt';
+if($wuapikey && file_stale($filename4c)){
 $url4c = 'https://api.weather.com/v3/wx/forecast/daily/5day?geocode='.$lat.','.$lon.'&language=en-US&format=json&units='.$wuapiunit.'&apiKey='.$wuapikey ;
 $ch4c = curl_init($url4c);
-$filename4c = 'jsondata/wuforecast.txt';
 $complete_save_loc4c = $filename4c;
-$fp4c = fopen($complete_save_loc4c, 'wb');
-curl_setopt($ch4c, CURLOPT_FILE, $fp4c);
-curl_setopt($ch4c, CURLOPT_HEADER, 0);
-curl_exec($ch4c);
-curl_close($ch4c);
-fclose($fp4c);}?>
-
-
+update_file($ch4c, $complete_save_loc4c);
+}}?>
 <?php // weather34 earthquakes curl based
+$filename1 = 'jsondata/eqnotification.txt';
+if(file_stale($filename1)){
 $url1 = 'https://earthquake-report.com/feeds/recent-eq?json';
 $ch1 = curl_init($url1);
-$filename1 = 'jsondata/eqnotification.txt';
 $complete_save_loc1 = $filename1;
-$fp1 = fopen($complete_save_loc1, 'wb');
-curl_setopt($ch1, CURLOPT_FILE, $fp1);
-curl_setopt($ch1, CURLOPT_HEADER, 0);
-curl_exec($ch1);
-curl_close($ch1);
-fclose($fp1);
+update_file($ch1, $complete_save_loc1);
+}
 ?>
 <?php //k-index curl based
+$filename2a = 'jsondata/kindex.txt';
+if(file_stale($filename2a)){
 $url2a = 'https://services.swpc.noaa.gov/products/geospace/planetary-k-index-dst.json';
 $ch2a = curl_init($url2a);
-$filename2a = 'jsondata/kindex.txt';
 $complete_save_loc2a = $filename2a;
-$fp2a = fopen($complete_save_loc2a, 'wb');
-curl_setopt($ch2a, CURLOPT_FILE, $fp2a);
-curl_setopt($ch2a, CURLOPT_HEADER, 0);
-curl_exec($ch2a);
-curl_close($ch2a);
-fclose($fp2a);
+update_file($ch2a, $complete_save_loc2a);
+}
 ?>
 
 <?php // weather34 purple air quality  curl based
 if($purpleairhardware=='yes'){
+$filename4 = 'jsondata/purpleair.txt';
+if(file_stale($filename4)){
 $url4 = 'https://www.purpleair.com/json?show='.$purpleairID.'';
 $ch4 = curl_init($url4);
-$filename4 = 'jsondata/purpleair.txt';
 $complete_save_loc4 = $filename4;
-$fp4 = fopen($complete_save_loc4, 'wb');
-curl_setopt($ch4, CURLOPT_FILE, $fp4);
-curl_setopt($ch4, CURLOPT_HEADER, 0);
-curl_exec($ch4);
-curl_close($ch4);
-fclose($fp4);}
+update_file($ch4, $complete_save_loc4);
+}}
 ?>
 <?php
 // Meteoalarm rss feed based
 
+$filename3='jsondata/meteoalarm.txt';
+if(file_stale($filename3)){
+exec ("wget -r -O '$filename3' '$templateroot'//meteoalarm/warnings1.php?country='$alarmcountry'\&region='$alarmregion'");}
 
-exec ("wget -r -O jsondata/meteoalarm.txt '$templateroot'//meteoalarm/warnings1.php?country='$alarmcountry'\&region='$alarmregion'");
-
-?>  
+?>


### PR DESCRIPTION
weewxcron can currently be used to easily exhaust api calls as
there is not rate-limiting.  This patch will only perform api
calls if the output files have aged significantly (based on
$wuupdate or 1 hour based on file).  Added a force arg (must match
password) that will unconditionally update the files.

Also fixed the default client cron-call to actually honor $wuupdate
(was much longer).