### PR TITLE
Added support for setting PWS_STATE in environment to replace jsondata

### DIFF
--- a/advisory.php
+++ b/advisory.php
@@ -4,7 +4,7 @@
 <?php 
 if ($position6=="forecast3wularge.php" || $position6=="forecast3wu.php"){
 
-$json='jsondata/wuforecast.txt';
+$json=$PWS_STATE.'/wuforecast.txt';
 $weather34wuurl=file_get_contents($json);
 $parsed_weather34wujson = json_decode($weather34wuurl,false);
 {    

--- a/airqualitymodule.php
+++ b/airqualitymodule.php
@@ -33,7 +33,7 @@ function map($value, $fromLow, $fromHigh, $toLow, $toHigh){
     // Re-zero back to the to range
     return $tmpValue + $toLow;
 }
-$json_string             = file_get_contents("jsondata/purpleair.txt");
+$json_string             = file_get_contents($PWS_STATE.'/purpleair.txt');
 $parsed_json             = json_decode($json_string);
 //$aqiweather["aqi"]       = $parsed_json->{'results'}[1]->{'PM2_5Value'};
 $aqiweather["aqi"]       = number_format(pm25_to_aqi(($parsed_json->{'results'}[0]->{'PM2_5Value'} + $parsed_json->{'results'}[1]->{'PM2_5Value'}) / 2),1);
@@ -44,8 +44,8 @@ $aqiweather["city"]      = $parsed_json->{'results'}[0]->{'ID'};
 $aqiweather["label"]     = $parsed_json->{'results'}[0]->{'Label'};
 $a="";if($aqiweather["aqi"]==$a){$aqiweather["aqi"] = "0" ;}
 ?>
-<div class="updatedtime"><span><?php if(file_exists('jsondata/purpleair.txt') && time() - filemtime('jsondata/purpleair.txt')<1800) {
-  echo $online." ".date($timeFormat, filemtime('jsondata/purpleair.txt'));
+<div class="updatedtime"><span><?php if(file_exists($PWS_STATE.'/purpleair.txt') && time() - filemtime($PWS_STATE.'/purpleair.txt')<1800) {
+  echo $online." ".date($timeFormat, filemtime($PWS_STATE.'/purpleair.txt'));
   } else {
   echo $offline. '<offline> Offline </offline>';
   }?></div> 

--- a/aqiinfo.php
+++ b/aqiinfo.php
@@ -146,7 +146,7 @@ else if ($weather["cloudbase3"]>0){echo "<div class=cloudbase0>".$weather["cloud
          
  
 	<?php  //air quality	
-$json_string             = file_get_contents("jsondata/aqi.txt");
+$json_string             = file_get_contents($PWS_STATE."/aqi.txt");
 $parsed_json             = json_decode($json_string);
 $aqiweather["aqi"]       = $parsed_json->{'aqiv'};
 $aqiweather["aqiozone"]  = $parsed_json->{'data'}->{'iaqi'}->{'o3'}->{'v'};

--- a/aurora.php
+++ b/aurora.php
@@ -1,6 +1,6 @@
-<?php include('shared.php');
+<?php require_once(__DIR__.'/load_settings.php');include('shared.php');
 // K-INDEX & SOLAR DATA FOR HOMEWEATHERSTATION TEMPLATE RADIO HAMS REJOICE :-) //
-$str = file_get_contents('jsondata/kindex.txt');
+$str = file_get_contents($PWS_STATE.'/kindex.txt');
 $json = array_reverse(json_decode($str,false));
 $kp =  $json[1][1];
 
@@ -133,7 +133,7 @@ Aurora scatter communications using specialised operating techniques allows comm
   
         <br>  <br> <br>     
  <?php echo '<svg viewBox="0 0 32 32" width=7 height=7 fill=#9aba2f stroke=#9aba2f stroke-linecap=round stroke-linejoin=round stroke-width=6.25%><path d="M16 14 L16 23 M16 8 L16 10" /><circle cx=16 cy=16 r=14 /></svg>';
-; echo " Last Updated: ".date("H:i:s",filemtime('jsondata/kindex.txt'));?>
+; echo " Last Updated: ".date("H:i:s",filemtime($PWS_STATE.'/kindex.txt'));?>
 
 </article> 
 

--- a/barometer.php
+++ b/barometer.php
@@ -101,7 +101,7 @@ else echo "Wind Gusts Becoming Strong Caution Required <notifyorange>" .$weather
 
 <?php //earthquakes magnitude 6+
 date_default_timezone_set($TZ);
-$json_string=file_get_contents('jsondata/eqnotification.txt');
+$json_string=file_get_contents($PWS_STATE.'/eqnotification.txt');
 $parsed_json=json_decode($json_string,true);$magnitude = array();$eqtitle = array();$depth = array();$time = array();$lati = array();$longi = array();$eventime = array();
 for ($i = 0; $i < sizeof($parsed_json); $i++) {
 $magnitude[$i]=$parsed_json{$i}{'magnitude'};$eqtitle[$i]=$parsed_json{$i}['title'];$depth[$i]=$parsed_json{$i}['depth'];$time[$i]=$parsed_json{$i}['date_time'];

--- a/common.php
+++ b/common.php
@@ -1,5 +1,5 @@
 <?php
-include('settings1.php');
+require_once(__DIR__.'/load_settings.php');
 date_default_timezone_set($TZ);
 try {
   # set $UTC if blank
@@ -7,7 +7,7 @@ try {
     $UTC = strval((new DateTimeZone($TZ))->getOffset(new DateTime("now"))/3600);
   }
 } catch (Exception $e) { }
-if(!isset($livedata2)) { $livedata2='jsondata/livedata2.txt'; }
+if(!isset($livedata2)) { $livedata2=$PWS_STATE.'/livedata2.txt'; }
 //translations for HOMEWEATHERSTATION TEMPLATE UPDATED 2nd November added set locale
 mb_internal_encoding('UTF-8');
 mb_http_output('UTF-8');

--- a/copy_folder_inside_to_skins_folder/w34skin/skin.conf
+++ b/copy_folder_inside_to_skins_folder/w34skin/skin.conf
@@ -83,13 +83,13 @@ skin_semantics = 2
            [[[DAILYCHARTS]]]
                 encoding = strict_ascii	
                 template = result.csv.tmpl
-                HTML_ROOT = /[YOUR_OWN_PATH]/mbcharts            
+                HTML_ROOT = /[YOUR_OWN_PATH]/chartdata
 
     # Charts that plot "by month"
             [[[MONTHLYCHARTS]]]
                 encoding = strict_ascii
                 template = MMYYYY.csv.tmpl
-                HTML_ROOT = /[YOUR_OWN_PATH]/mbcharts/chartdata
+                HTML_ROOT = /[YOUR_OWN_PATH]/chartdata
                 
               
 
@@ -97,7 +97,7 @@ skin_semantics = 2
             [[[YEARLYCHARTS]]]
                 encoding = strict_ascii
                 template = YYYY.csv.tmpl
-                HTML_ROOT = /[YOUR_OWN_PATH]/mbcharts/chartdata
+                HTML_ROOT = /[YOUR_OWN_PATH]/chartdata
                 
     
     [[WXSTATS]]

--- a/createdb.php
+++ b/createdb.php
@@ -1,6 +1,6 @@
 <?php
 //weather34 weatherstation create the database then create the tables 
-include('settings1.php');
+require_once(__DIR__.'/load_settings.php');
 $servername = $db_host;
 $username = $db_user;
 $password = $db_pass;

--- a/currentconditionsds.php
+++ b/currentconditionsds.php
@@ -32,9 +32,9 @@ $now =date('G.i');
 
 ?><head>
 <div class="updatedtimecurrent">
-<?php $forecastime=filemtime('jsondata/darksky.txt');
-	$weather34wuurl = file_get_contents("jsondata/dark.txt");
-	if(filesize('jsondata/darksky.txt')<1){echo "".$offline. " Offline<br>";}else echo $online,"";echo " ",	date($timeFormat,$forecastime);	?></div>
+<?php $forecastime=filemtime($PWS_STATE.'/darksky.txt');
+	$weather34wuurl = file_get_contents($PWS_STATE.'/darksky.txt');
+	if(filesize($PWS_STATE.'/darksky.txt')<1){echo "".$offline. " Offline<br>";}else echo $online,"";echo " ",	date($timeFormat,$forecastime);	?></div>
  <div class="darkskyiconcurrent">
  <span1><?php 
   

--- a/currentconditionsmetar34.php
+++ b/currentconditionsmetar34.php
@@ -23,9 +23,9 @@ $twighlight_begin =date('G:i', $result['civil_twilight_begin']);
 $twighlight_end =date('G:i', $result['civil_twilight_end']);
 $now =date('G.i');?>
 <div class="updatedtimecurrent">
-<?php $forecastime=filemtime('jsondata/metar34.txt');
-	$weather34wuurl = file_get_contents("jsondata/metar34.txt");
-	if(filesize('jsondata/metar34.txt')<160){echo $online;}else echo $online,"";echo " ",	date($timeFormat,$forecastime);	?></div>
+<?php $forecastime=filemtime($PWS_STATE.'/metar34.txt');
+	$weather34wuurl = file_get_contents($PWS_STATE.'/metar34.txt');
+	if(filesize($PWS_STATE.'/metar34.txt')<160){echo $online;}else echo $online,"";echo " ",	date($timeFormat,$forecastime);	?></div>
 <div class="darkskyiconcurrent"><span1>
 <?php 
 
@@ -51,7 +51,7 @@ else if($weather["wind_speed_avg"]>20 && $now <$sunr2){echo "<img rel='prefetch'
 else if($weather["wind_speed_avg"]>20){echo "<img rel='prefetch' src='css/icons/windy.svg' width='70px' height='60px' alt='weather34 windy icon'>";}
 
 //metar with darksky fallback
-else if(filesize('jsondata/metar34.txt')<160){
+else if(filesize($PWS_STATE.'/metar34.txt')<160){
 echo "<img rel='prefetch' src='css/icons/offline.svg'width='70px' height='60px' alt='weather34 offline icon'>";} 	
 else echo "<img rel='prefetch' src='css/icons/".$sky_icon."' width='70px' height='60px'>";
 ?></div>
@@ -83,7 +83,7 @@ else if($weather["temp"] -$weather["dewpoint"] <0.5  && $weather["temp"]>5){echo
 else if($weather["wind_speed_avg"]>40){echo "Strong Wind ".$alert."<br>Conditions" ;}
 else if($weather["wind_speed_avg"]>30){echo "Very Windy ".$alert."<br>Conditions";}
 else if($weather["wind_speed_avg"]>20){echo "Moderate Wind <br>Conditions";}
-else if(filesize('jsondata/metar34.txt')<160){echo "<uppercase>Conditions<br>Not Available</uppercase>";}
+else if(filesize($PWS_STATE.'/metar34.txt')<160){echo "<uppercase>Conditions<br>Not Available</uppercase>";}
 //metar conditions
 else echo '<uppercase>',$sky_desc.'</uppercase>'; 
 

--- a/currentconditionsmetar34davis.php
+++ b/currentconditionsmetar34davis.php
@@ -13,7 +13,7 @@ $suns2 =date('G.i', $result['sunset']);$sunr2 =date('G.i', $result['sunrise']);$
 $sunsethour =date('G', $result['sunset']);$twighlight_begin =date('G:i', $result['civil_twilight_begin']);$twighlight_end =date('G:i', $result['civil_twilight_end']);$now =date('G.i');
 ?>
 <div class="updatedtimecurrent">
-<?php $forecastime=filemtime('jsondata/metar34.txt');$weather34wuurl = file_get_contents("jsondata/metar34.txt");if(filesize('jsondata/metar34.txt')<10){echo  $online;}
+<?php $forecastime=filemtime($PWS_STATE.'/metar34.txt');$weather34wuurl = file_get_contents($PWS_STATE.'/metar34.txt');if(filesize($PWS_STATE.'/metar34.txt')<10){echo  $online;}
 else echo $online,"";echo " ",	date($timeFormat,$forecastime);	?></div>
 <div class="cloudconverter">
 <?php //cloudbase-weather34
@@ -44,7 +44,7 @@ else if($weather["wind_speed_avg"]>=15 && $now >$suns2){echo "<img rel='prefetch
 else if($weather["wind_speed_avg"]>=15 && $now <$sunr2){echo "<img rel='prefetch' src='css/icons/nt_windy.svg' width='70px' height='60px' alt='weather34 windy icon'>";}
 else if($weather["wind_speed_avg"]>=15){echo "<img rel='prefetch' src='css/icons/windy.svg' width='70px' height='60px' alt='weather34 windy icon'>";}
 //metar with darksky fallback-weather34
-else if(filesize('jsondata/metar34.txt')<160){
+else if(filesize($PWS_STATE.'/metar34.txt')<160){
 echo "<img rel='prefetch' src='css/icons/offline.svg'width='70px' height='60px' alt='weather34 offline icon'>";} 	
 else echo "<img rel='prefetch' src='css/icons/".$sky_icon."' width='70px' height='60px'>";
 ?></div>
@@ -71,7 +71,7 @@ else if($weather["wind_speed_avg"]>=40){echo "Strong Wind ".$alert."<br>Conditio
 else if($weather["wind_speed_avg"]>=30){echo "Very Windy ".$alert."<br>Conditions";}
 else if($weather["wind_speed_avg"]>=22){echo "Moderate Wind <br>Conditions";}
 else if($weather["wind_speed_avg"]>=15){echo "Breezy <br>Conditions";}
-else if(filesize('jsondata/metar34.txt')<160){echo "<uppercase>Conditions<br>Not Available</uppercase>";} 
+else if(filesize($PWS_STATE.'/metar34.txt')<160){echo "<uppercase>Conditions<br>Not Available</uppercase>";} 
 //metar conditions-weather34
 else echo '<uppercase>',$sky_desc.'</uppercase><br>'; 
 ?>

--- a/earthquake.php
+++ b/earthquake.php
@@ -1,4 +1,4 @@
-<?php include('livedata.php');include('common.php');date_default_timezone_set($TZ);$json_string=file_get_contents('jsondata/eqnotification.txt');$parsed_json=json_decode($json_string,true);
+<?php include('livedata.php');include('common.php');date_default_timezone_set($TZ);$json_string=file_get_contents($PWS_STATE.'/eqnotification.txt');$parsed_json=json_decode($json_string,true);
 $software    = 'Cumulus <span>Software</span>';
 $designedfor    = '<br>For Cumulus';
 $magnitude=number_format($parsed_json{0}{'magnitude'},1);

--- a/easywxsetup.php
+++ b/easywxsetup.php
@@ -1,5 +1,5 @@
 <?php
-include('settings1.php');
+require_once(__DIR__.'/load_settings.php');
  // HOMEWEATHERSTATION EASY SETUP AUGUST 2016 //
  // SIMPLE EASY PHP BASED AND CSS //
  // DEVELOPED BY BRIAN UNDERDOWN //
@@ -10,7 +10,7 @@ include('settings1.php');
 IF (ISSET($_POST["Submit"])) {
 
 function loadFile($file) {
-  if(!file_exists($file)) return [];
+  if(!is_readable($file)) return [];
   require $file;
   unset($file);
   return get_defined_vars();
@@ -27,10 +27,10 @@ $floats = ['lon', 'lat'];
 $args = array_merge($args, array_fill_keys($floats, FILTER_VALIDATE_FLOAT));
 $s1 = filter_var_array($s1, $args, false);
 // check for change...
-$s1orig = loadFile('./settings1.php');
+$s1orig = loadFile($PWS_SETTINGS);
 if($s1 != $s1orig) {
-  if (!is_writable(".")) {
-    echo ("<p>Unable to write to the website's folder. Make sure the root of the website is writable by your webserver.<br/></p>");
+  if (!is_writable($PWS_STATE)) {
+    echo ("<p>Unable to write to the website's '".$PWS_STATE."' folder.<br/></p>");
     die();
   }
   $code = "<?php\n";
@@ -38,7 +38,7 @@ if($s1 != $s1orig) {
     /// ${var} = "{value}";\n
     $code .= '$' . $var . ' = ' . var_export($value, true) . ";\n";
   }
-  file_put_contents('settings1.php', $code);
+  file_put_contents($PWS_SETTINGS, $code);
 }
 }
 ?>

--- a/eq.php
+++ b/eq.php
@@ -3,7 +3,7 @@
 //current eq
 date_default_timezone_set($TZ);
 //$json_string=file_get_contents('http://earthquake-report.com/feeds/recent-eq?json');
-$json_string=file_get_contents('jsondata/eqnotification.txt');
+$json_string=file_get_contents($PWS_STATE.'/eqnotification.txt');
 $parsed_json=json_decode($json_string,true);
 $magnitude1=$parsed_json{0}{'magnitude'};
 $magnitude=number_format($magnitude1,1);
@@ -24,7 +24,7 @@ $eqdist;if ($weather["wind_units"] == 'mph') {$eqdist = round(distance($lat, $lo
 $eqdista;if ($weather["wind_units"] == 'mph') {$eqdista = round(distance($lat, $lon, $lati, $longi) * 0.621371) ."<smallrainunit>mi";} else {$eqdista = round(distance($lat, $lon, $lati, $longi)) ."<smallrainunit>km";} ?>  
 <div class="updatedtime">
 <span><?php 
-$updated=filemtime('jsondata/eqnotification.txt');
+$updated=filemtime($PWS_STATE.'/eqnotification.txt');
 echo  $online, " ",date($timeFormat, $updated);?></span>
  </div>
 <br />

--- a/eqlist.php
+++ b/eqlist.php
@@ -16,7 +16,7 @@ error_reporting(0);
 <?php //current eqlist
 date_default_timezone_set($TZ);
 //$json_string=file_get_contents('http://earthquake-report.com/feeds/recent-eq?json');
-$json_string=file_get_contents('jsondata/eqnotification.txt');
+$json_string=file_get_contents($PWS_STATE.'/eqnotification.txt');
 $parsed_json=json_decode($json_string,true);
 $magnitude = array();
 $eqtitle = array();

--- a/eualert.php
+++ b/eualert.php
@@ -66,7 +66,7 @@ As always to Brian Underdown who designed the weather34 template.
  ----------------------------------------------------------------------------------------- */
 include('livedata.php');include('common.php');
 date_default_timezone_set($TZ);
-$json_string = file_get_contents('jsondata/darksky.txt');
+$json_string = file_get_contents($PWS_STATE.'/darksky.txt');
 $parsed_json = json_decode($json_string);
 $alerttype = $parsed_json->{'alerts'}[0]->{"title"};
 $type = explode(" ", $alerttype);

--- a/forecast3ds.php
+++ b/forecast3ds.php
@@ -11,7 +11,7 @@
 ?>
 
 <style>hilo{font-size:.8em}</style>
-<div class="updatedtime1"><?php $forecastime=filemtime('jsondata/darksky.txt');$weather34wuurl = file_get_contents("jsondata/darksky.txt");if(filesize('jsondata/darksky.txt')<1){echo "".$offline. " Offline<br>";}else echo $online,"";echo " ",	date($timeFormat,$forecastime);	?></div>
+<div class="updatedtime1"><?php $forecastime=filemtime($PWS_STATE.'/darksky.txt');$weather34wuurl = file_get_contents($PWS_STATE.'/darksky.txt');if(filesize($PWS_STATE.'/darksky.txt')<1){echo "".$offline. " Offline<br>";}else echo $online,"";echo " ",	date($timeFormat,$forecastime);	?></div>
 <div class="darkskyforecasthome"><div class="darkskydiv">
 <?php //begin darksky stuff        
 foreach ($darkskydayCond as $cond) {

--- a/forecast3wu.php
+++ b/forecast3wu.php
@@ -14,9 +14,9 @@ header('Content-type: text/html; charset=UTF-8');
 	# 	Code simplified by ktrue - 30-Mar-2019
 	####################################################################################################
 
-$jsonfile="jsondata/wuforecast.txt";if(!file_exists($jsonfile)) {return;}
+$jsonfile=$PWS_STATE.'/wuforecast.txt';if(!file_exists($jsonfile)) {return;}
 ?>
-<div class="updatedtime1"><?php $forecastime=filemtime('jsondata/wuforecast.txt');$weather34wuurl = file_get_contents("jsondata/wuforecast.txt");if(filesize('jsondata/wuforecast.txt')<1){echo "".$offline. "";}else echo $online,"";echo " ",	date($timeFormat,$forecastime);	?></div>
+<div class="updatedtime1"><?php $forecastime=filemtime($jsonfile);$weather34wuurl = file_get_contents($jsonfile);if(filesize($jsonfile)<1){echo "".$offline. "";}else echo $online,"";echo " ",	date($timeFormat,$forecastime);	?></div>
 <div class="darkskyforecasthome" ><div class="darkskydiv">
 <?php //begin wu stuff 
 $weather34wuurl=file_get_contents($jsonfile);$parsed_weather34wujson = json_decode($weather34wuurl,false);$wucount = 0;

--- a/forecast3wularge.php
+++ b/forecast3wularge.php
@@ -7,7 +7,7 @@
 	#   https://www.weather34.com 	                                                                   #
 	####################################################################################################
 //start the wu output
-$json='jsondata/wuforecast.txt';
+$json=$PWS_STATE.'/wuforecast.txt';
 $weather34wuurl=file_get_contents($json);
 $parsed_weather34wujson = json_decode($weather34wuurl,false);
 {    if ($parsed_weather34wujson->{'daypart'}[0]->{'iconCode'}[0]==null){
@@ -103,7 +103,7 @@ $parsed_weather34wujson = json_decode($weather34wuurl,false);
 	 $wuskydayUV8 = $parsed_weather34wujson->{'daypart'}[0]->{'uvIndex'}[8];
 	 
 	 }?>
-<div class="updatedtime1"><?php $forecastime=filemtime('jsondata/wuforecast.txt');$weather34wuurl = file_get_contents("jsondata/wuforecast.txt");if(filesize('jsondata/wuforecast.txt')<1){echo "".$offline. "";}else echo $online,"";echo " ",date($timeFormat,$forecastime);	?></div>
+<div class="updatedtime1"><?php $forecastime=filemtime($PWS_STATE.'/wuforecast.txt');$weather34wuurl = file_get_contents($PWS_STATE.'/wuforecast.txt');if(filesize($PWS_STATE.'/wuforecast.txt')<1){echo "".$offline. "";}else echo $online,"";echo " ",date($timeFormat,$forecastime);	?></div>
 <div class="wulargeforecasthome"><div class="wulargediv">
 <?php //begin wu stuff 
 //convert lightning index

--- a/homeindoor.php
+++ b/homeindoor.php
@@ -47,7 +47,7 @@ function map($value, $fromLow, $fromHigh, $toLow, $toHigh){
     // Re-zero back to the to range
     return $tmpValue + $toLow;
 }
-$json_string             = file_get_contents("jsondata/purpleair.txt");
+$json_string             = file_get_contents($PWS_STATE.'/purpleair.txt');
 $parsed_json             = json_decode($json_string);
 //$aqiweather["aqi"]       = $parsed_json->{'results'}[1]->{'PM2_5Value'};
 if(count($parsed_json->{'results'})>1)

--- a/index.php
+++ b/index.php
@@ -30,13 +30,14 @@ function loadSettings($file) {
     unset($file);
     return get_defined_vars();
 }
+require_once(__DIR__.'/load_settings.php');
 $s1d   = loadSettings('./settings1.default.php');
-$s1    = loadSettings('./settings1.php');
+$s1    = loadSettings($PWS_SETTINGS);
 $check = array_diff_key($s1d, $s1);
 if (!empty($check)) {
     //check if dir is writable
-    if (!is_writable(".")) {
-        echo ("<p>Unable to write to the website's folder. Make sure the root of the website is writable by your webserver.<br/>If you're using Apache on linux, Apache should be running as user 'www-data' and group 'www-data'. If so, run these commands or adjust them for Apache's user:group <br/><br/><i>find . -type d -exec sudo chown www-data:www-data {} \; -exec sudo chmod 2775 {} \;</i> <br/><br/>and <br/><br/><i>find . -type f -exec sudo chown www-data:www-data {} \; -exec sudo chmod 664 {} \;</i> <br/><br/>from within the root of your website's folder, probably located in '/var/www/example.com/html/pws.'<br/><br/><br/>or, do yourself a huge favor and navigate into your 'html' folder and use these 3 commands to automatically set the permissions on all files and folders created inside it:<br/><br/><i>chmod g+s .</i><br/><br/><i>setfacl -d -m g::rwx .</i><br/><br/><i>setfacl -d -m o::rx .</i></p>");
+    if (!is_writable($PWS_STATE)) {
+        echo ("<p>Unable to write to the website's '".$PWS_STATE."' folder. Make sure the directory is writable by your webserver.<br/>If you're using Apache on linux, Apache should be running as user 'www-data' and group 'www-data'. If so, run these commands or adjust them for Apache's user:group <br/><br/><i>find . -type d -exec sudo chown www-data:www-data {} \; -exec sudo chmod 2775 {} \;</i> <br/><br/>and <br/><br/><i>find . -type f -exec sudo chown www-data:www-data {} \; -exec sudo chmod 664 {} \;</i> <br/><br/>from within the directory '".$PWS_STATE."'<br/><br/><br/>or, do yourself a huge favor and navigate into your 'html' folder and use these 3 commands to automatically set the permissions on all files and folders created inside it:<br/><br/><i>chmod g+s .</i><br/><br/><i>setfacl -d -m g::rwx .</i><br/><br/><i>setfacl -d -m o::rx .</i></p>");
         die();
     }
     $s1   = array_merge($s1d, $s1);
@@ -45,7 +46,7 @@ if (!empty($check)) {
         /// ${var} = "{value}";\n
         $code .= '$' . $var . ' = ' . var_export($value, true) . ";\n";
     }
-    file_put_contents('./settings1.php', $code);
+    file_put_contents($PWS_SETTINGS, $code);
 }
 ####################################################################################################
 # HOME WEATHER STATION TEMPLATE by BRIAN UNDERDOWN 2017-2018-2019                    			   #
@@ -56,7 +57,7 @@ if (!empty($check)) {
 #   https://github.com/weather34/Weather34-Weatherflow                                             #
 ####################################################################################################
 //original weather34 script original css/svg/php by weather34 2015-2019 clearly marked as original by weather34//
-include_once('livedata.php');include_once('common.php');include_once('settings1.php'); date_default_timezone_set($TZ);?>
+include_once('livedata.php');include_once('common.php');date_default_timezone_set($TZ);?>
 <!DOCTYPE html>
 <html>
 <head>
@@ -133,7 +134,7 @@ if ('serviceWorker' in navigator) {
   <!--currentsky for homeweatherstation template-->
   <div class="weather-item"><div class="chartforecast">
          <!-- HOURLY & Outlook for homeweather station-->
-  <span class="yearpopup"> <a alt="nearby metar station" title="nearby metar station" href="metarnearby.php" data-lity><?php echo $chartinfo?> <?php echo 'Nearby Metar';?> <?php if(filesize('jsondata/metar34.txt')<160){echo "(<ored>Offline</ored>)";}else echo "" ?></a></span>
+  <span class="yearpopup"> <a alt="nearby metar station" title="nearby metar station" href="metarnearby.php" data-lity><?php echo $chartinfo?> <?php echo 'Nearby Metar';?> <?php if(filesize($PWS_STATE.'/metar34.txt')<160){echo "(<ored>Offline</ored>)";}else echo "" ?></a></span>
   <span class="monthpopup"><a href="windyradar.php" title="Windy.com Radar" alt="Windy.com Radar" data-lity><?php echo $chartinfo?> Radar</a></span>
   <span class="monthpopup"><a href="windywind.php" title="Windy.com Wind Map" alt="Windy.com Wind Map" data-lity><?php echo $chartinfo?> Wind Map</a></span>
   </div>

--- a/jsondata/wuupdate.php
+++ b/jsondata/wuupdate.php
@@ -1,7 +1,6 @@
 <?php
 chdir(dirname(__FILE__));
-include_once('../settings.php');
-include_once('../settings1.php');
+include_once(dirname(__DIR__).'/settings.php');
 date_default_timezone_set($TZ);
 // NEW checkwx.com API 
 if(file_exists('metar34.txt')&&time()- filemtime('metar34.txt')>1800){

--- a/livedata.php
+++ b/livedata.php
@@ -923,10 +923,10 @@ if ($weather["wind_units"] == 'mph') {
 
 
 
-// darksky api forecast and current script for HOMEWEATHERSTATION gets data from jsondata/darksky.json Friday 2nd December 2016 //
+// darksky api forecast and current script for HOMEWEATHERSTATION gets data from $PWS_STATE/darksky.json Friday 2nd December 2016 //
 //$units = 'auto';  // Read the API docs for full details // default is auto
 date_default_timezone_set($TZ);
-$json = 'jsondata/darksky.txt'; 
+$json = $PWS_STATE.'/darksky.txt'; 
 $json = file_get_contents($json); 
 $response = json_decode($json, true);       
 if ($response != null) {
@@ -1031,5 +1031,5 @@ $E = (6.11 * pow(10 , (7.5 * $Tdc / (237.7 + $Tdc))));
 $wetbulbcalc = (((0.00066 * $P) * $Tc) + ((4098 * $E) / pow(($Tdc + 237.7) , 2) * $Tdc)) / ((0.00066 * $P) + (4098 * $E) / pow(($Tdc + 237.7) , 2));
 $wetbulbx =number_format($wetbulbcalc,1);
 // K-INDEX & SOLAR DATA FOR WEATHER34 HOMEWEATHERSTATION TEMPLATE RADIO HAMS REJOICE :-) //
-$kp =0;$str = file_get_contents('jsondata/kindex.txt');$str = json_decode($str,false);if ($str){$json = array_reverse($str);$kp = $json[1][1];}?>
+$kp =0;$str = file_get_contents($PWS_STATE.'/kindex.txt');$str = json_decode($str,false);if ($str){$json = array_reverse($str);$kp = $json[1][1];}?>
 <?php $file = $_SERVER["SCRIPT_NAME"];$break = Explode('/', $file);$mod34file = $break[count($break) - 1];?>

--- a/load_settings.php
+++ b/load_settings.php
@@ -1,0 +1,17 @@
+<?php
+// PWS_STATE should be an absolute path
+if (isset($_SERVER['PWS_STATE'])) {
+  $PWS_STATE = $_SERVER['PWS_STATE'];
+} else {
+  $PWS_STATE = __DIR__ . '/jsondata';
+}
+$PWS_SETTINGS = $PWS_STATE . '/settings1.php';
+if (! is_readable($PWS_SETTINGS)) {
+  if (is_readable('./settings1.php') && is_writable($PWS_STATE)) {
+    // migrate settings1 to new location
+    copy('./settings1.php', $PWS_SETTINGS);
+  }
+}
+if(is_readable($PWS_SETTINGS)) {
+  include $PWS_SETTINGS;
+}

--- a/manifest.php
+++ b/manifest.php
@@ -1,5 +1,5 @@
 <?php
-include('./settings1.php');
+require_once(__DIR__.'/load_settings.php');
 $sitebase=substr($_SERVER['REQUEST_URI'], 0, strrpos($_SERVER['REQUEST_URI'], '/') + 1);
 $manifest = [
     "name" => $stationName.' Weather',

--- a/mbcharts/chartdata.php
+++ b/mbcharts/chartdata.php
@@ -1,0 +1,48 @@
+<?php
+require_once(dirname(__DIR__).'/load_settings.php');
+if(! isset($_GET['csv'])) { die(); }
+// Strict filter for filename...
+$file = preg_replace('/[^a-z0-9_\-]/', '', $_GET['csv']);
+if(empty($file)) { die(); }
+// file from chartdata only...
+$filename = $PWS_STATE . '/chartdata/' . $file . '.csv';
+// check if it exists, access, etc
+if(! is_file($filename)) { http_response_code(404); die(); }
+if(! is_readable($filename)) { http_response_code(403); die(); }
+$stat = @stat($filename);
+$etag = sprintf('%x-%x-%x', $stat['ino'], $stat['size'], $stat['mtime'] * 1000000);
+
+// still valid?
+if(isset($_SERVER['HTTP_IF_NONE_MATCH']) && $_SERVER['HTTP_IF_NONE_MATCH'] == $etag) {
+  header('Etag: "' . $etag . '"');
+  http_response_code(304);
+  die();
+}
+if(isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) && strtotime($_SERVER['HTTP_IF_MODIFIED_SINCE']) >= $stat['mtime']) {
+  header('Last-Modified: ' . date('r', $stat['mtime']));
+  http_response_code(304);
+  die();
+}
+
+// send the file...
+// CSV file
+header('Content-Type: text/csv');
+
+// File metadata
+header('Last-Modified: ' . date('r', $stat['mtime']));
+header('Etag: "' . $etag . '"');
+
+//No cache
+header('Expires: 0');
+header('Cache-Control: must-revalidate');
+header('Pragma: public');
+
+//Define file size
+header('Content-Length: ' . $stat['size']);
+
+ob_clean();
+flush();
+if(@readfile($filename) === false) {
+  http_response_code(403);
+  die();
+}

--- a/mbcharts/monthlybarometer.php
+++ b/mbcharts/monthlybarometer.php
@@ -62,7 +62,7 @@
 		var dataPoints2 = [];
 		$.ajax({
 			type: "GET",
-			url: "chartdata/<?php echo $weatherfile;?>.csv",
+			url: "chartdata.php?csv=<?php echo $weatherfile;?>",
 			dataType: "text",
 			cache:false,
 			success: function(data) {processData1(data),processData2(data);}

--- a/mbcharts/monthlydewpoint.php
+++ b/mbcharts/monthlydewpoint.php
@@ -42,7 +42,7 @@ $(document).ready(function () {
 	var dataPoints2 = [];
 	$.ajax({
 		type: "GET",
-		url: "chartdata/<?php echo $weatherfile;?>.csv",
+		url: "chartdata.php?csv=<?php echo $weatherfile;?>",
 		dataType: "text",
 		cache:false,
 		success: function(data) {

--- a/mbcharts/monthlyrainfall.php
+++ b/mbcharts/monthlyrainfall.php
@@ -52,7 +52,7 @@ $(document).ready(function () {
 	var dataPoints2 = [];
 	$.ajax({
 		type: "GET",
-		url: "chartdata/<?php echo $weatherfile;?>.csv",
+		url: "chartdata.php?csv=<?php echo $weatherfile;?>",
 		dataType: "text",
 		cache:false,
 		success: function(data) {

--- a/mbcharts/monthlysolar.php
+++ b/mbcharts/monthlysolar.php
@@ -34,7 +34,7 @@ $(document).ready(function () {
 	var dataPoints2 = [];
 	$.ajax({
 		type: "GET",
-		url: "chartdata/<?php echo $weatherfile;?>.csv",
+		url: "chartdata.php?csv=<?php echo $weatherfile;?>",
 		dataType: "text",
 		cache:false,
 		success: function(data) {

--- a/mbcharts/monthlytemperature.php
+++ b/mbcharts/monthlytemperature.php
@@ -41,7 +41,7 @@ $(document).ready(function () {
 	var dataPoints2 = [];
 	$.ajax({
 		type: "GET",
-		url: "chartdata/<?php echo $weatherfile;?>.csv",
+		url: "chartdata.php?csv=<?php echo $weatherfile;?>",
 		dataType: "text",
 		cache:false,
 		success: function(data) {

--- a/mbcharts/monthlywindspeedgust.php
+++ b/mbcharts/monthlywindspeedgust.php
@@ -43,7 +43,7 @@ $(document).ready(function () {
 	var dataPoints2 = [];
 	$.ajax({
 		type: "GET",
-		url: "chartdata/<?php echo $weatherfile;?>.csv",
+		url: "chartdata.php?csv=<?php echo $weatherfile;?>",
 		dataType: "text",
 		cache:false,
 		success: function(data) {processData1(data),processData2(data);}

--- a/mbcharts/todaybarometer.php
+++ b/mbcharts/todaybarometer.php
@@ -69,7 +69,7 @@ $(document).ready(function () {
 	var dataPoints2 = [];
 	$.ajax({
 		type: "GET",
-		url: "result.csv",
+		url: "chartdata.php?csv=result",
 		dataType: "text",
 		cache:false,
 		success: function(data) {processData1(data),processData2(data);}

--- a/mbcharts/todaybarometersmall.php
+++ b/mbcharts/todaybarometersmall.php
@@ -49,7 +49,7 @@
 	var dataPoints2 = [];
 	$.ajax({
 			type: "GET",
-			url: "result.csv",
+			url: "chartdata.php?csv=result",
 			dataType: "text",
 			cache:false,
 			success: function(data) {processData1(data),processData2(data);}

--- a/mbcharts/todayrainfall.php
+++ b/mbcharts/todayrainfall.php
@@ -55,7 +55,7 @@ $(document).ready(function () {
 	var dataPoints2 = [];
 	$.ajax({
 		type: "GET",
-		url: "result.csv",
+		url: "chartdata.php?csv=result",
 		dataType: "text",
 		cache:false,
 		success: function(data) {processData1(data),processData2(data);}

--- a/mbcharts/todayrainfallsmall.php
+++ b/mbcharts/todayrainfallsmall.php
@@ -51,7 +51,7 @@
 		var dataPoints2 = [];
 		$.ajax({
 			type: "GET",
-			url: "result.csv",
+			url: "chartdata.php?csv=result",
 			dataType: "text",
 			cache:false,
 			success: function(data) {processData1(data),processData2(data);}

--- a/mbcharts/todaysolar.php
+++ b/mbcharts/todaysolar.php
@@ -35,7 +35,7 @@
 		var dataPoints2 = [];
 		$.ajax({
 			type: "GET",
-			url: "result.csv",
+			url: "chartdata.php?csv=result",
 			dataType: "text",
 			cache:false,
 			success: function(data) {processData1(data),processData2(data);}

--- a/mbcharts/todaysolarsmall.php
+++ b/mbcharts/todaysolarsmall.php
@@ -35,7 +35,7 @@
 		var dataPoints2 = [];
 		$.ajax({
 			type: "GET",
-			url: "result.csv",
+			url: "chartdata.php?csv=result",
 			dataType: "text",
 			cache:false,
 			success: function(data) {processData1(data),processData2(data);}

--- a/mbcharts/todaytemperature.php
+++ b/mbcharts/todaytemperature.php
@@ -44,7 +44,7 @@
 		var dataPoints2 = [];
 		$.ajax({
 			type: "GET",
-			url: "result.csv",
+			url: "chartdata.php?csv=result",
 			dataType: "text",
 			cache:false,
 			success: function(data) {processData1(data),processData2(data);}

--- a/mbcharts/todaytempsmall.php
+++ b/mbcharts/todaytempsmall.php
@@ -48,7 +48,7 @@
 		var dataPoints2 = [];
 		$.ajax({
 			type: "GET",
-			url: "result.csv",
+			url: "chartdata.php?csv=result",
 			dataType: "text",
 			cache:false,
 			success: function(data) {processData1(data),processData2(data);}

--- a/mbcharts/todayuv.php
+++ b/mbcharts/todayuv.php
@@ -34,7 +34,7 @@ echo '
 	var dataPoints2 = [];
 	$.ajax({
 			type: "GET",
-			url: "result.csv",
+			url: "chartdata.php?csv=result",
 			dataType: "text",
 			cache:false,
 			success: function(data) {processData1(data),processData2(data);}

--- a/mbcharts/todayuvsmall.php
+++ b/mbcharts/todayuvsmall.php
@@ -35,7 +35,7 @@
 		var dataPoints2 = [];
 		$.ajax({
 			type: "GET",
-			url: "result.csv",
+			url: "chartdata.php?csv=result",
 			dataType: "text",
 			cache:false,
 			success: function(data) {processData1(data),processData2(data);}

--- a/mbcharts/todaywinddirection.php
+++ b/mbcharts/todaywinddirection.php
@@ -36,7 +36,7 @@
 		var dataPoints2 = [];
 		$.ajax({
 			type: "GET",
-			url: "result.csv",
+			url: "chartdata.php?csv=result",
 			dataType: "text",
 			cache:false,
 			success: function(data) {processData1(data),processData2(data);}

--- a/mbcharts/todaywindspeedgust.php
+++ b/mbcharts/todaywindspeedgust.php
@@ -45,7 +45,7 @@
 		var dataPoints2 = [];
 		$.ajax({
 			type: "GET",
-			url: "result.csv",
+			url: "chartdata.php?csv=result",
 			dataType: "text",
 			cache:false,
 			success: function(data) {processData1(data),processData2(data);}

--- a/mbcharts/todaywindspeedsmall.php
+++ b/mbcharts/todaywindspeedsmall.php
@@ -45,7 +45,7 @@
 		var dataPoints2 = [];
 		$.ajax({
 			type: "GET",
-			url: "result.csv",
+			url: "chartdata.php?csv=result",
 			dataType: "text",
 			cache:false,
 			success: function(data) {processData1(data),processData2(data);}

--- a/mbcharts/yearlybarometer.php
+++ b/mbcharts/yearlybarometer.php
@@ -64,7 +64,7 @@
 		var dataPoints2 = [];
 		$.ajax({
 			type: "GET",
-			url: "chartdata/<?php echo $weatherfile;?>.csv",
+			url: "chartdata.php?csv=<?php echo $weatherfile;?>",
 			dataType: "text",
 			cache:false,
 			success: function(data) {processData1(data),processData2(data);}

--- a/mbcharts/yearlybarometermedium.php
+++ b/mbcharts/yearlybarometermedium.php
@@ -63,7 +63,7 @@
 		var dataPoints2 = [];
 		$.ajax({
 			type: "GET",
-			url: "chartdata/<?php echo $weatherfile;?>.csv",
+			url: "chartdata.php?csv=<?php echo $weatherfile;?>",
 			dataType: "text",
 			cache:false,
 			success: function(data) {processData1(data),processData2(data);}

--- a/mbcharts/yearlydewpoint.php
+++ b/mbcharts/yearlydewpoint.php
@@ -41,7 +41,7 @@
 		var dataPoints2 = [];
 		$.ajax({
 			type: "GET",
-			url: "chartdata/<?php echo $weatherfile;?>.csv",
+			url: "chartdata.php?csv=<?php echo $weatherfile;?>",
 			dataType: "text",
 			cache:false,
 			success: function(data) {processData1(data),processData2(data);}

--- a/mbcharts/yearlyrainfall.php
+++ b/mbcharts/yearlyrainfall.php
@@ -51,7 +51,7 @@
 		var dataPoints2 = [];
 		$.ajax({
 			type: "GET",
-			url: "chartdata/<?php echo $weatherfile;?>.csv",
+			url: "chartdata.php?csv=<?php echo $weatherfile;?>",
 			dataType: "text",
 			cache:false,
 			success: function(data) {processData1(data),processData2(data);}

--- a/mbcharts/yearlyrainfallmedium.php
+++ b/mbcharts/yearlyrainfallmedium.php
@@ -51,7 +51,7 @@
 		var dataPoints2 = [];
 		$.ajax({
 			type: "GET",
-			url: "chartdata/<?php echo $weatherfile;?>.csv",
+			url: "chartdata.php?csv=<?php echo $weatherfile;?>",
 			dataType: "text",
 			cache:false,
 			success: function(data) {processData1(data),processData2(data);}

--- a/mbcharts/yearlysolar.php
+++ b/mbcharts/yearlysolar.php
@@ -34,7 +34,7 @@
 		var dataPoints2 = [];
 		$.ajax({
 			type: "GET",
-			url: "chartdata/<?php echo $weatherfile;?>.csv",
+			url: "chartdata.php?csv=<?php echo $weatherfile;?>",
 			dataType: "text",
 			cache:false,
 			success: function(data) {processData1(data),processData2(data);}

--- a/mbcharts/yearlytemperature.php
+++ b/mbcharts/yearlytemperature.php
@@ -42,7 +42,7 @@
 		var dataPoints2 = [];
 		$.ajax({
 			type: "GET",
-			url: "chartdata/<?php echo $weatherfile;?>.csv",
+			url: "chartdata.php?csv=<?php echo $weatherfile;?>",
 			dataType: "text",
 			cache:false,
 			success: function(data) {processData1(data),processData2(data);}

--- a/mbcharts/yearlytemperaturemedium.php
+++ b/mbcharts/yearlytemperaturemedium.php
@@ -42,7 +42,7 @@
 		var dataPoints2 = [];
 		$.ajax({
 			type: "GET",
-			url: "chartdata/<?php echo $weatherfile;?>.csv",
+			url: "chartdata.php?csv=<?php echo $weatherfile;?>",
 			dataType: "text",
 			cache:false,
 			success: function(data) {processData1(data),processData2(data);}

--- a/mbcharts/yearlywindspeedgust.php
+++ b/mbcharts/yearlywindspeedgust.php
@@ -45,7 +45,7 @@
 		var dataPoints2 = [];
 		$.ajax({
 			type: "GET",
-			url: "chartdata/<?php echo $weatherfile;?>.csv",
+			url: "chartdata.php?csv=<?php echo $weatherfile;?>",
 			dataType: "text",
 			cache:false,
 			success: function(data) {processData1(data),processData2(data);}

--- a/mbcharts/yearlywindspeedgustmedium.php
+++ b/mbcharts/yearlywindspeedgustmedium.php
@@ -46,7 +46,7 @@
 		var dataPoints2 = [];
 		$.ajax({
 			type: "GET",
-			url: "chartdata/<?php echo $weatherfile;?>.csv",
+			url: "chartdata.php?csv=<?php echo $weatherfile;?>",
 			dataType: "text",
 			cache:false,
 			success: function(data) {processData1(data),processData2(data);}

--- a/metar/metar34get.php
+++ b/metar/metar34get.php
@@ -1,5 +1,5 @@
 <?php
-error_reporting(0); 
+require_once(dirname(__DIR__).'/load_settings.php');error_reporting(0); 
 $result = date_sun_info(time(), $lat, $lon);
 $sunr=date_sunrise(time(), SUNFUNCS_RET_STRING, $lat, $lon, $rise_zenith, $UTC);
 $suns=date_sunset(time(), SUNFUNCS_RET_STRING, $lat, $lon, $set_zenith, $UTC);
@@ -7,7 +7,7 @@ $suns2 =date('G.i', $result['sunset']);
 $sunrs2 =date('G.i', $result['sunrise']);
 $now =date('G.i');
  //weather34 wxcheck API aviation metar script May 2018 
-$json_string             = file_get_contents("jsondata/metar34.txt");
+$json_string             = file_get_contents($PWS_STATE.'/metar34.txt');
 $parsed_json             = json_decode($json_string);
 $metar34time       = $parsed_json->{'data'}[0]->{'observed'};
 $metar34raw       = $parsed_json->{'data'}[0]->{'raw_text'};

--- a/metar34get.php
+++ b/metar34get.php
@@ -7,7 +7,7 @@ $suns2 =date('G.i', $result['sunset']);
 $sunrs2 =date('G.i', $result['sunrise']);
 $now =date('G.i');
  //weather34 wxcheck API aviation metar script May 2018 
-$json_string             = file_get_contents("jsondata/metar34.txt");
+$json_string             = file_get_contents($PWS_STATE.'/metar34.txt');
 $parsed_json             = json_decode($json_string);
 $metar34time       = $parsed_json->{'data'}[0]->{'observed'};
 $metar34raw       = $parsed_json->{'data'}[0]->{'raw_text'};

--- a/meteoalarmpop.php
+++ b/meteoalarmpop.php
@@ -1,4 +1,4 @@
-<?php include('settings.php');include('livedata.php');include('jsondata/meteoalarmsettings.php');include('common.php');
+<?php include('settings.php');include('livedata.php');include($PWS_STATE.'/meteoalarmsettings.php');include('common.php');
 
 
 
@@ -15,7 +15,7 @@
 ?>
 <?php 
 date_default_timezone_set($TZ);
-$json_string             = file_get_contents("jsondata/meteoalarm.txt");
+$json_string             = file_get_contents($PWS_STATE.'/meteoalarm.txt');
 $parsed_json             = json_decode($json_string);
 
 $published =  $parsed_json->{'warnings'}->{"regions"}[0]->{"published"};

--- a/meteobridge_lookup.php
+++ b/meteobridge_lookup.php
@@ -1,5 +1,5 @@
 <?php 
-include('w34stats.php');
+include($PWS_STATE.'/w34stats.php');
 $cumulus_live = file_get_contents($livedata);
 $cumulus = explode(" ", $cumulus_live);
 $cumulus = array_map(function($v) { if($v == 'NULL') {

--- a/outlookwu.php
+++ b/outlookwu.php
@@ -12,7 +12,7 @@ include_once('settings.php');include('livedata.php');
 	//original weather34 script original css/svg/php by weather34 2015-2019 clearly marked as original by weather34//
 	
 //start the wu output
-$json='jsondata/wuforecast.txt';
+$json=$PWS_STATE.'/wuforecast.txt';
 $weather34wuurl=file_get_contents($json);
 $parsed_weather34wujson = json_decode($weather34wuurl,false);
 $parsed_weather34wujson1 = json_decode($weather34wuurl,true);

--- a/purpleair.php
+++ b/purpleair.php
@@ -41,7 +41,7 @@ function map($value, $fromLow, $fromHigh, $toLow, $toHigh){
     // Re-zero back to the to range
     return $tmpValue + $toLow;
 }
-$json_string             = file_get_contents("jsondata/purpleair.txt");
+$json_string             = file_get_contents($PWS_STATE.'/purpleair.txt');
 $parsed_json             = json_decode($json_string);
 //$aqiweather["aqi"]       = $parsed_json->{'results'}[1]->{'PM2_5Value'};
 $aqiweather["aqi"]       = number_format(pm25_to_aqi(($parsed_json->{'results'}[0]->{'PM2_5Value'} + $parsed_json->{'results'}[1]->{'PM2_5Value'}) / 2),1);

--- a/settings.php
+++ b/settings.php
@@ -1,5 +1,5 @@
 <?php 
-include('settings1.php');error_reporting(0); 
+require_once(__DIR__.'/load_settings.php');error_reporting(0);
 	####################################################################################################
 	#	HOME WEATHER STATION TEMPLATE SETUP please set up and check thoroughly                         #
 	#	CREATED FOR HOMEWEATHERSTATION TEMPLATE at https://weather34.com/homeweatherstation/index.html # 

--- a/solaruvwu.php
+++ b/solaruvwu.php
@@ -14,7 +14,7 @@ if ($weather["solar"]==0){echo "<div class=solarluxtodaydark>".$weather["solar"]
 else if ($weather["solar"]>0){echo "<div class=solarluxtoday>".$weather["solar"];}?></div></div></div>
 <div class="solarluxtodayword"><valuetext>Solar Radiation</valuetext></div><div class="solarwrap"></div>
 <?php
-$json='jsondata/wuforecast.txt';
+$json=$PWS_STATE.'/wuforecast.txt';
 $weather34wuurl=file_get_contents($json);
 $parsed_weather34wujson = json_decode($weather34wuurl,false);
 $parsed_weather34wujson1 = json_decode($weather34wuurl,true);

--- a/updater.php
+++ b/updater.php
@@ -1,6 +1,5 @@
 <!-- begin updater.php  30-Mar-2019 -->
 <?php
-include_once('settings1.php');
 include_once('common.php');
 date_default_timezone_set($TZ);
 ?>

--- a/uvindexwu.php
+++ b/uvindexwu.php
@@ -104,7 +104,7 @@ align-items:center;justify-content:center;margin-bottom:10px;top:0}
   <article>  
    <div class=actualt>&nbsp;&nbsp UV-INDEX Forecast</div>        
    <div class="uvcontainer1"><?php 
- $json='jsondata/wuforecast.txt';
+ $json=$PWS_STATE.'/wuforecast.txt';
 $weather34wuurl=file_get_contents($json);
 $parsed_weather34wujson = json_decode($weather34wuurl,false);
 $parsed_weather34wujson1 = json_decode($weather34wuurl,true);

--- a/weatherflow.php
+++ b/weatherflow.php
@@ -1,4 +1,4 @@
 <?php error_reporting(0);include('settings.php');
-$section = file_get_contents('https://swd.weatherflow.com/swd/rest/observations/device/'.$weatherflowdairID.'?api_key='.$somethinggoeshere.'');file_put_contents('jsondata/weatherflow1.txt',$section);
-$section1 = file_get_contents('https://swd.weatherflow.com/swd/rest/observations/station/'.$weatherflowID.'?api_key='.$somethinggoeshere.'');file_put_contents('jsondata/weatherflow.txt',$section1);
+$section = file_get_contents('https://swd.weatherflow.com/swd/rest/observations/device/'.$weatherflowdairID.'?api_key='.$somethinggoeshere.'');file_put_contents($PWS_STATE.'/weatherflow1.txt',$section);
+$section1 = file_get_contents('https://swd.weatherflow.com/swd/rest/observations/station/'.$weatherflowID.'?api_key='.$somethinggoeshere.'');file_put_contents($PWS_STATE.'/weatherflow.txt',$section1);
 ?>

--- a/weatherflowuvsolar.php
+++ b/weatherflowuvsolar.php
@@ -2,7 +2,7 @@
 //weather34 weatherflow uv module 27th September 2018 //
 
 include_once('livedata.php');header('Content-type: text/html; charset=utf-8');
-$file1 = 'jsondata/weatherflow.txt';
+$file1 = $PWS_STATE.'/weatherflow.txt';
 $url = $file1;
 $content = file_get_contents($url);
 $json = json_decode($content, true);    
@@ -15,7 +15,7 @@ foreach($json['obs'] as $item)
    $weatherflow['lux']  = $item['brightness'];  
 }
 
-$section1 = file_get_contents('https://swd.weatherflow.com/swd/rest/observations/station/'.$weatherflowID.'?api_key='.$somethinggoeshere.'');file_put_contents('jsondata/weatherflow.txt',$section1);
+$section1 = file_get_contents('https://swd.weatherflow.com/swd/rest/observations/station/'.$weatherflowID.'?api_key='.$somethinggoeshere.'');file_put_contents($PWS_STATE.'/weatherflow.txt',$section1);
 ?>
 
 <div class="updatedtime"><span><?php if(file_exists($file1)&&time()- filemtime($file1)>900)echo '

--- a/weewxcron.php
+++ b/weewxcron.php
@@ -28,7 +28,7 @@ function update_file($ch, $filename) {
 <?php
 $metarapikey=trim($metarapikey);
 $icao1=trim($icao1);
-$filename2 = 'jsondata/metar34.txt';
+$filename2 = $PWS_STATE.'/metar34.txt';
 if($metarapikey && $icao1 && file_stale($filename2)) {
 $w34header= array("X-API-KEY:".$metarapikey."",);
 $complete_save_loc2 = $filename2;
@@ -41,7 +41,7 @@ update_file($ch, $complete_save_loc2);
 if ($position6=="forecast3ds.php" || $position6=='forecast3wu.php' || $position6=='forecast3wularge.php' || $position4 == "advisory.php"){
 // weather34 darksky  curl based
 $apikey=trim($apikey);
-$filename4a = 'jsondata/darksky.txt';
+$filename4a = $PWS_STATE.'/darksky.txt';
 if($apikey && file_stale($filename4a, 3600*0.8)){
 $url4a = 'https://api.forecast.io/forecast/'.$apikey.'/'.$lat.','.$lon.'?lang='.$language.'&units='.$darkskyunit ;
 $ch4a = curl_init($url4a);
@@ -52,7 +52,7 @@ update_file($ch4a, $complete_save_loc4a);
 if ($position6=="forecast3wu.php" || $position6=="forecast3wularge.php"){
 // weather34 weather underground  curl based
 $wuapikey=trim($wuapikey);
-$filename4c = 'jsondata/wuforecast.txt';
+$filename4c = $PWS_STATE.'/wuforecast.txt';
 if($wuapikey && file_stale($filename4c)){
 $url4c = 'https://api.weather.com/v3/wx/forecast/daily/5day?geocode='.$lat.','.$lon.'&language=en-US&format=json&units='.$wuapiunit.'&apiKey='.$wuapikey ;
 $ch4c = curl_init($url4c);
@@ -60,7 +60,7 @@ $complete_save_loc4c = $filename4c;
 update_file($ch4c, $complete_save_loc4c);
 }}?>
 <?php // weather34 earthquakes curl based
-$filename1 = 'jsondata/eqnotification.txt';
+$filename1 = $PWS_STATE.'/eqnotification.txt';
 if(file_stale($filename1)){
 $url1 = 'https://earthquake-report.com/feeds/recent-eq?json';
 $ch1 = curl_init($url1);
@@ -69,7 +69,7 @@ update_file($ch1, $complete_save_loc1);
 }
 ?>
 <?php //k-index curl based
-$filename2a = 'jsondata/kindex.txt';
+$filename2a = $PWS_STATE.'/kindex.txt';
 if(file_stale($filename2a)){
 $url2a = 'https://services.swpc.noaa.gov/products/geospace/planetary-k-index-dst.json';
 $ch2a = curl_init($url2a);
@@ -80,7 +80,7 @@ update_file($ch2a, $complete_save_loc2a);
 
 <?php // weather34 purple air quality  curl based
 if($purpleairhardware=='yes'){
-$filename4 = 'jsondata/purpleair.txt';
+$filename4 = $PWS_STATE.'/purpleair.txt';
 if(file_stale($filename4)){
 $url4 = 'https://www.purpleair.com/json?show='.$purpleairID.'';
 $ch4 = curl_init($url4);
@@ -91,7 +91,7 @@ update_file($ch4, $complete_save_loc4);
 <?php
 // Meteoalarm rss feed based
 
-$filename3='jsondata/meteoalarm.txt';
+$filename3=$PWS_STATE.'/meteoalarm.txt';
 if(file_stale($filename3)){
 exec ("wget -r -O '$filename3' '$templateroot'//meteoalarm/warnings1.php?country='$alarmcountry'\&region='$alarmregion'");}
 

--- a/wflightning.php
+++ b/wflightning.php
@@ -3,7 +3,7 @@
 <?php 
 $url2 = 'https://swd.weatherflow.com/swd/rest/observations/station/'.$weatherflowID.'?api_key=5675886d24b02a37107eb5076d5e1d9f'; 
 $ch2 = curl_init($url2);
-$filename2 = 'jsondata/weatherflow.txt';
+$filename2 = $PWS_STATE.'/weatherflow.txt';
 $complete_save_loc2 = $filename2; 
 $fp2 = fopen($complete_save_loc2, 'wb'); 
 curl_setopt($ch2, CURLOPT_FILE, $fp2);
@@ -14,7 +14,7 @@ fclose($fp2);
 ?>
 <?php 
     //weather34 weatherflow air lightning
-$file1 = 'jsondata/weatherflow.txt';
+$file1 = $PWS_STATE.'/weatherflow.txt';
 $url = $file1;
 $content = file_get_contents($url);
 $json = json_decode($content, true);    

--- a/wxcharts.php
+++ b/wxcharts.php
@@ -8,7 +8,7 @@
 	#   https://www.weather34.com 	                                                                   #
 	####################################################################################################
 
-include('livedata.php');include('common.php');include('settings1.php');
+include('livedata.php');include('common.php');
 date_default_timezone_set($TZ);?>
 <!DOCTYPE html>
 <html>


### PR DESCRIPTION
Settings are now loaded from the directory PWS_STATE from the environment,
or jsondata by default.  Any existing settings1.php is copied there
(if possible).  All references to jsondata are replaced by PWS_STATE,
and load_settings.php is required whenever PWS_STATE is needed.

This is the first crack at this, but pages all appear to load (at least as they did before :)
